### PR TITLE
fix/useEffect callbacks within Pixi reconciler

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "fbjs": "^0.8.0",
     "performance-now": "^2.1.0",
-    "react-reconciler": "^0.20.4",
+    "react-reconciler": "^0.21.0",
     "scheduler": "^0.15.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
This change makes the scheduler version consistently `0.15.0` across all dependencies

It's worth considering what implications this will have for projects running `react` versions before `16.9.0`
These projects will have scheduler `0.13.6`